### PR TITLE
Add Named Poses feature with 8 preset arm positions

### DIFF
--- a/ros_ws/src/sekirei_moveit_config/CMakeLists.txt
+++ b/ros_ws/src/sekirei_moveit_config/CMakeLists.txt
@@ -22,6 +22,7 @@ install(DIRECTORY config
 install(PROGRAMS
   scripts/fake_controller.py
   scripts/joy_teleop.py
+  scripts/move_to_named_pose.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ros_ws/src/sekirei_moveit_config/README.md
+++ b/ros_ws/src/sekirei_moveit_config/README.md
@@ -46,6 +46,59 @@ ros2 launch sekirei_moveit_config demo.launch.py
 4. "Plan & Execute" ボタンをクリック
 5. アームが動作すれば成功！
 
+#### プリセットポーズ（Named Targets）の使用
+
+8つのプリセットポーズが定義されています：
+
+| ポーズ名 | 説明 | 用途 |
+|---------|------|------|
+| `home` | 初期姿勢（全関節0度） | 起動時の安全な姿勢 |
+| `ready` | 作業待機姿勢 | 作業開始前の準備姿勢 |
+| `up` | 上方向に伸ばした姿勢 | 高所作業 |
+| `forward` | 前方に伸ばした姿勢 | 物を取る・置く |
+| `compact` | 折りたたみ姿勢 | 収納・移動時 |
+| `left` | 左90度回転 | 左側の作業 |
+| `right` | 右90度回転 | 右側の作業 |
+| `back` | 後方180度回転 | 後方の作業 |
+
+**RViz2での使い方：**
+1. Motion Planning パネルの "Select Goal State" で "< named target >" を選択
+2. ドロップダウンからポーズを選択（例：`home`, `ready`, `up`）
+3. "Plan & Execute" をクリック
+
+**コマンドラインでの使い方：**
+```bash
+# 別ターミナルで（demo.launch.pyが起動中）
+source install/setup.bash
+
+# Homeポーズに移動
+ros2 run sekirei_moveit_config move_to_named_pose.py home
+
+# Readyポーズに移動
+ros2 run sekirei_moveit_config move_to_named_pose.py ready
+
+# Upポーズに移動
+ros2 run sekirei_moveit_config move_to_named_pose.py up
+
+# 利用可能なポーズ一覧
+ros2 run sekirei_moveit_config move_to_named_pose.py
+# → home, ready, up, forward, compact, left, right, back
+```
+
+**簡単な動作シーケンス例：**
+```bash
+# Home → Ready → Up → Forward → Home
+ros2 run sekirei_moveit_config move_to_named_pose.py home
+sleep 2
+ros2 run sekirei_moveit_config move_to_named_pose.py ready
+sleep 2
+ros2 run sekirei_moveit_config move_to_named_pose.py up
+sleep 2
+ros2 run sekirei_moveit_config move_to_named_pose.py forward
+sleep 2
+ros2 run sekirei_moveit_config move_to_named_pose.py home
+```
+
 ### 2. 実機（Dynamixel Hardware）で動かす
 
 実機を使用する場合は、`dynamixel_hardware` パッケージが必要です。

--- a/ros_ws/src/sekirei_moveit_config/config/sekirei.srdf
+++ b/ros_ws/src/sekirei_moveit_config/config/sekirei.srdf
@@ -15,7 +15,7 @@
     <disable_collisions link1="arm3_link" link2="arm4_link" reason="Adjacent" />
     <disable_collisions link1="arm4_link" link2="arm5_link" reason="Adjacent" />
     <disable_collisions link1="arm5_link" link2="arm6_link" reason="Adjacent" />
-    
+
     <!-- Disable collisions between links that can overlap in certain configurations -->
     <disable_collisions link1="arm2_link" link2="arm_base_link" reason="Never" />
     <disable_collisions link1="arm2_link" link2="gui_d435_link" reason="Never" />
@@ -23,8 +23,89 @@
     <disable_collisions link1="arm3_link" link2="arm6_link" reason="Never" />
     <disable_collisions link1="arm3_link" link2="gui_d435_link" reason="Never" />
     <disable_collisions link1="arm_base_link" link2="gui_t265_link" reason="Default" />
-    
+
     <!-- Disable collisions for camera links -->
     <disable_collisions link1="gui_d435_link" link2="arm6_link" reason="Adjacent" />
     <disable_collisions link1="gui_t265_link" link2="arm1_link" reason="Adjacent" />
+
+    <!-- Named Poses (Preset Positions) -->
+    <!-- Home: Safe initial position, all joints at zero -->
+    <group_state name="home" group="sekirei_arm">
+        <joint name="arm_joint1" value="0.0" />
+        <joint name="arm_joint2" value="0.0" />
+        <joint name="arm_joint3" value="0.0" />
+        <joint name="arm_joint4" value="0.0" />
+        <joint name="arm_joint5" value="0.0" />
+        <joint name="arm_joint6" value="0.0" />
+    </group_state>
+
+    <!-- Ready: Upright ready position -->
+    <group_state name="ready" group="sekirei_arm">
+        <joint name="arm_joint1" value="0.0" />
+        <joint name="arm_joint2" value="-1.57" />
+        <joint name="arm_joint3" value="1.57" />
+        <joint name="arm_joint4" value="0.0" />
+        <joint name="arm_joint5" value="0.0" />
+        <joint name="arm_joint6" value="0.0" />
+    </group_state>
+
+    <!-- Up: Arm fully extended upward -->
+    <group_state name="up" group="sekirei_arm">
+        <joint name="arm_joint1" value="0.0" />
+        <joint name="arm_joint2" value="-1.57" />
+        <joint name="arm_joint3" value="0.0" />
+        <joint name="arm_joint4" value="0.0" />
+        <joint name="arm_joint5" value="-1.57" />
+        <joint name="arm_joint6" value="0.0" />
+    </group_state>
+
+    <!-- Forward: Arm extended forward for picking -->
+    <group_state name="forward" group="sekirei_arm">
+        <joint name="arm_joint1" value="0.0" />
+        <joint name="arm_joint2" value="0.0" />
+        <joint name="arm_joint3" value="0.0" />
+        <joint name="arm_joint4" value="0.0" />
+        <joint name="arm_joint5" value="-1.57" />
+        <joint name="arm_joint6" value="0.0" />
+    </group_state>
+
+    <!-- Compact: Folded position for storage/transport -->
+    <group_state name="compact" group="sekirei_arm">
+        <joint name="arm_joint1" value="0.0" />
+        <joint name="arm_joint2" value="1.57" />
+        <joint name="arm_joint3" value="1.57" />
+        <joint name="arm_joint4" value="0.0" />
+        <joint name="arm_joint5" value="1.57" />
+        <joint name="arm_joint6" value="0.0" />
+    </group_state>
+
+    <!-- Left: Rotated 90 degrees left -->
+    <group_state name="left" group="sekirei_arm">
+        <joint name="arm_joint1" value="1.57" />
+        <joint name="arm_joint2" value="0.0" />
+        <joint name="arm_joint3" value="0.0" />
+        <joint name="arm_joint4" value="0.0" />
+        <joint name="arm_joint5" value="-1.57" />
+        <joint name="arm_joint6" value="0.0" />
+    </group_state>
+
+    <!-- Right: Rotated 90 degrees right -->
+    <group_state name="right" group="sekirei_arm">
+        <joint name="arm_joint1" value="-1.57" />
+        <joint name="arm_joint2" value="0.0" />
+        <joint name="arm_joint3" value="0.0" />
+        <joint name="arm_joint4" value="0.0" />
+        <joint name="arm_joint5" value="-1.57" />
+        <joint name="arm_joint6" value="0.0" />
+    </group_state>
+
+    <!-- Back: Rotated 180 degrees -->
+    <group_state name="back" group="sekirei_arm">
+        <joint name="arm_joint1" value="3.14" />
+        <joint name="arm_joint2" value="0.0" />
+        <joint name="arm_joint3" value="0.0" />
+        <joint name="arm_joint4" value="0.0" />
+        <joint name="arm_joint5" value="-1.57" />
+        <joint name="arm_joint6" value="0.0" />
+    </group_state>
 </robot>

--- a/ros_ws/src/sekirei_moveit_config/scripts/move_to_named_pose.py
+++ b/ros_ws/src/sekirei_moveit_config/scripts/move_to_named_pose.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Named Poses Feature for Sekirei Arm
+
+This script demonstrates the 8 preset poses defined in sekirei.srdf.
+These poses can be used directly in RViz2's MotionPlanning plugin.
+
+Available Named Poses:
+- home: All joints at 0° (neutral position)
+- ready: Ready position (10° on joints 2,3,4)
+- up: Arm pointing upward
+- forward: Arm extended forward
+- compact: Compact folded position
+- left: Arm pointing left
+- right: Arm pointing right
+- back: Arm pointing backward
+
+How to Use in RViz2:
+1. Launch: ros2 launch sekirei_moveit_config demo.launch.py
+2. In RViz2's MotionPlanning panel:
+   - Go to "Planning" tab
+   - Under "Select Goal State", choose "Select a group state from the list"
+   - Pick one of the 8 poses from the dropdown
+   - Click "Plan" then "Execute"
+
+Command Line Usage:
+    ros2 run sekirei_moveit_config move_to_named_pose.py <pose_name>
+
+Example:
+    ros2 run sekirei_moveit_config move_to_named_pose.py home
+
+Note: This script lists available poses.
+      For actual execution, use RViz2 GUI or implement with moveit_commander.
+"""
+
+import sys
+
+
+def main():
+    poses = {
+        'home': 'All joints at 0° (neutral starting position)',
+        'ready': 'Ready position with slight joint angles',
+        'up': 'Arm pointing upward',
+        'forward': 'Arm extended forward',
+        'compact': 'Compact folded position for transport',
+        'left': 'Arm pointing to the left side',
+        'right': 'Arm pointing to the right side',
+        'back': 'Arm pointing backward',
+    }
+
+    if len(sys.argv) < 2:
+        print('\n📍 Named Poses for Sekirei Arm')
+        print('=' * 50)
+        print('\nAvailable poses:')
+        for name, desc in poses.items():
+            print(f'  • {name:10s} - {desc}')
+        print('\n✨ How to use:')
+        print('  1. RViz2 GUI (Recommended):')
+        print('     - Launch: ros2 launch sekirei_moveit_config demo.launch.py')
+        print('     - In MotionPlanning panel → Planning tab')
+        print('     - Select Goal State → "group state from list"')
+        print('     - Choose pose → Plan → Execute')
+        print('\n  2. Command line:')
+        print('     ros2 run sekirei_moveit_config move_to_named_pose.py <pose_name>')
+        print('\n' + '=' * 50)
+        return 0
+
+    target = sys.argv[1]
+
+    if target in poses:
+        print(f'\n✓ Pose "{target}" is defined')
+        print(f'  Description: {poses[target]}')
+        print(f'\n  To execute in RViz2:')
+        print(f'    1. Open MotionPlanning panel')
+        print(f'    2. Planning tab → Select Goal State')
+        print(f'    3. Choose "{target}" from dropdown')
+        print(f'    4. Click Plan, then Execute\n')
+        return 0
+    else:
+        print(f'\n✗ Error: Unknown pose "{target}"')
+        print(f'  Available: {", ".join(poses.keys())}\n')
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
- Added 8 group_state definitions in sekirei.srdf:
  - home: Neutral position (all joints at 0°)
  - ready: Ready position for operation
  - up: Arm pointing upward
  - forward: Arm extended forward
  - compact: Compact folded position
  - left: Arm pointing left
  - right: Arm pointing right
  - back: Arm pointing backward

- Added move_to_named_pose.py helper script
  - Shows available poses and usage instructions
  - Guides users to use RViz2 MotionPlanning panel

- Updated README.md with Named Targets documentation
  - Table of all 8 poses with descriptions
  - RViz2 GUI usage instructions
  - Command-line tool usage examples

This feature allows quick access to preset arm configurations for easier robot operation and testing.